### PR TITLE
If G_USER_DIRECTORY_MUSIC is not set, do not prompt user to import it

### DIFF
--- a/src/info-bar-import-music.c
+++ b/src/info-bar-import-music.c
@@ -33,10 +33,10 @@
 gboolean info_bar_import_music_will_be_useful(PraghaApplication *pragha)
 {
 
-	const char *home = getenv("HOME");
+	const char *home = getenv ("HOME");
 	const char *dir = g_get_user_special_dir (G_USER_DIRECTORY_MUSIC);
 	//if G_USER_DIRECTORY_MUSIC equals $HOME then it is not set
-	gboolean is_g_user_directory_music_set = (strcmp(dir,home) == 0);
+	gboolean is_g_user_directory_music_set = !(strcmp (dir,home) == 0);
 	return pragha_application_is_first_run (pragha) &&
 	         is_g_user_directory_music_set &&
 	         dir;

--- a/src/info-bar-import-music.c
+++ b/src/info-bar-import-music.c
@@ -25,13 +25,21 @@
 #include <glib/gi18n.h>
 #endif
 
+#include <stdlib.h>
+
 #include "pragha-utils.h"
 #include "pragha.h"
 
 gboolean info_bar_import_music_will_be_useful(PraghaApplication *pragha)
 {
+
+	const char *home = getenv("HOME");
+	const char *dir = g_get_user_special_dir (G_USER_DIRECTORY_MUSIC);
+	//if G_USER_DIRECTORY_MUSIC equals $HOME then it is not set
+	gboolean is_g_user_directory_music_set = (strcmp(dir,home) == 0);
 	return pragha_application_is_first_run (pragha) &&
-	         g_get_user_special_dir (G_USER_DIRECTORY_MUSIC);
+	         is_g_user_directory_music_set &&
+	         dir;
 }
 
 static void info_bar_response_cb(GtkInfoBar *info_bar, gint response_id, gpointer user_data)

--- a/src/info-bar-import-music.c
+++ b/src/info-bar-import-music.c
@@ -35,11 +35,10 @@ gboolean info_bar_import_music_will_be_useful(PraghaApplication *pragha)
 
 	const char *home = getenv ("HOME");
 	const char *dir = g_get_user_special_dir (G_USER_DIRECTORY_MUSIC);
-	//if G_USER_DIRECTORY_MUSIC equals $HOME then it is not set
-	gboolean is_g_user_directory_music_set = !(strcmp (dir,home) == 0);
+	//if G_USER_DIRECTORY_MUSIC equals $HOME then it is not set properly
+	gboolean is_g_user_directory_music_set = dir && (strcmp (dir,home) != 0);
 	return pragha_application_is_first_run (pragha) &&
-	         is_g_user_directory_music_set &&
-	         dir;
+	         is_g_user_directory_music_set;
 }
 
 static void info_bar_response_cb(GtkInfoBar *info_bar, gint response_id, gpointer user_data)


### PR DESCRIPTION
If G_USER_DIRECTORY_MUSIC == HOME, then XDG_MUSIC_DIR is most probably not set properly and the user should not be prompted to import his home directory on the first run of pragha.

I could not figure out a better way to check if XDG_MUSIC_DIR is properly set, but I think this is sane enough.