### PR TITLE
Fix for the issue 129

### DIFF
--- a/src/pragha-playlist.c
+++ b/src/pragha-playlist.c
@@ -46,6 +46,7 @@
  * @view - The playlist tree view widget
  * @widget - The parent widget containing the view
  * @changing: If current platlist change is in progress
+ * @implicit_track: True when a track is not started explicitly by user
  * @no_tracks: Total no. of tracks in the current playlist
  * @unplayed_tracks: Total no. of tracks that haven't been played
  * @rand: To generate random numbers
@@ -83,6 +84,7 @@ struct _PraghaPlaylist {
 
 	gboolean             changing;
 	gboolean             dragging;
+   gboolean             implicit_track;
 	gint                 no_tracks;
 	GError              *track_error;
 
@@ -475,6 +477,8 @@ pragha_playlist_get_next_track (PraghaPlaylist *playlist)
 void
 pragha_playlist_go_prev_track (PraghaPlaylist *playlist)
 {
+   playlist->implicit_track = TRUE;
+
 	PraghaMusicobject *mobj = NULL;
 	mobj = pragha_playlist_get_prev_track (playlist);
 
@@ -485,6 +489,8 @@ pragha_playlist_go_prev_track (PraghaPlaylist *playlist)
 void
 pragha_playlist_go_any_track (PraghaPlaylist *playlist)
 {
+   playlist->implicit_track = FALSE;
+
 	PraghaMusicobject *mobj = NULL;
 	mobj = pragha_playlist_get_any_track (playlist);
 
@@ -494,6 +500,8 @@ pragha_playlist_go_any_track (PraghaPlaylist *playlist)
 void
 pragha_playlist_go_next_track (PraghaPlaylist *playlist)
 {
+   playlist->implicit_track = TRUE;
+
 	PraghaMusicobject *mobj = NULL;
 	mobj = pragha_playlist_get_next_track (playlist);
 
@@ -522,6 +530,7 @@ pragha_playlist_stopped_playback (PraghaPlaylist *playlist)
 		ret = gtk_tree_model_iter_next(playlist->model, &iter);
 	}
 	playlist->unplayed_tracks = playlist->no_tracks;
+   playlist->implicit_track = FALSE;
 
 	/* Remove old references */
 	if (playlist->rand_track_refs) {
@@ -3294,6 +3303,8 @@ pragha_playlist_restore_tracks (PraghaPlaylist *cplaylist)
 void
 pragha_playlist_init_playlist_state (PraghaPlaylist *cplaylist)
 {
+   cplaylist->implicit_track = FALSE;
+
 	gchar *ref = NULL;
 	GtkTreePath *path = NULL;
 
@@ -4091,6 +4102,12 @@ pragha_playlist_activate_unique_mobj(PraghaPlaylist* cplaylist, PraghaMusicobjec
 		pragha_playlist_activate_path(cplaylist, path);
 		gtk_tree_path_free (path);
 	}
+}
+
+gboolean 
+pragha_playlist_get_implicit_track (PraghaPlaylist* playlist)
+{
+   return playlist->implicit_track;
 }
 
 gint

--- a/src/pragha-playlist.h
+++ b/src/pragha-playlist.h
@@ -132,6 +132,7 @@ gboolean pragha_playlist_propagate_event(PraghaPlaylist* cplaylist, GdkEventKey 
 void pragha_playlist_activate_path        (PraghaPlaylist* cplaylist, GtkTreePath *path);
 void pragha_playlist_activate_unique_mobj (PraghaPlaylist* cplaylist, PraghaMusicobject *mobj);
 
+gboolean pragha_playlist_get_implicit_track (PraghaPlaylist* playlist);
 gint pragha_playlist_get_no_tracks      (PraghaPlaylist *playlist);
 gint pragha_playlist_get_no_unplayed_tracks (PraghaPlaylist *playlist);
 

--- a/src/pragha-window.c
+++ b/src/pragha-window.c
@@ -104,9 +104,8 @@ backend_error_dialog_response_cb (GtkDialog *dialog, gint response, PraghaApplic
 void
 gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error, gpointer user_data)
 {
-	GtkWidget *dialog;
-
 	PraghaApplication *pragha = user_data;
+	GtkWidget *dialog;
 
 	const gchar *file = pragha_musicobject_get_file (pragha_backend_get_musicobject (backend));
 
@@ -135,6 +134,7 @@ gui_backend_error_update_current_playlist_cb (PraghaBackend *backend, const GErr
 	playlist = pragha_application_get_playlist (pragha);
 
 	pragha_playlist_set_track_error (playlist, pragha_backend_get_error (backend));
+   pragha_playlist_go_next_track (playlist);
 }
 
 static gboolean

--- a/src/pragha-window.c
+++ b/src/pragha-window.c
@@ -103,19 +103,8 @@ backend_error_dialog_response_cb (GtkDialog *dialog, gint response, PraghaApplic
 }
 
 void
-gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error, gpointer user_data)
+gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error, PraghaApplication *pragha)
 {
-	PraghaApplication *pragha = user_data;
-   PraghaPlaylist *playlist = pragha_application_get_playlist (pragha);
-
-   /* 
-    * Don't show error dialog if the playback of the currupted file 
-    * is not started by user explicitly 
-    */
-   if (pragha_playlist_get_implicit_track(playlist)) {
-      return;
-   }
-
 	GtkWidget *dialog;
 
 	const gchar *file = pragha_musicobject_get_file (pragha_backend_get_musicobject (backend));
@@ -145,7 +134,18 @@ gui_backend_error_update_current_playlist_cb (PraghaBackend *backend, const GErr
 	playlist = pragha_application_get_playlist (pragha);
 
 	pragha_playlist_set_track_error (playlist, pragha_backend_get_error (backend));
-   pragha_playlist_go_next_track (playlist);
+
+   /* 
+    * Don't show error dialog if the playback of the currupted file 
+    * is not started by user explicitly 
+    */
+   if (pragha_playlist_get_implicit_track(playlist)) {
+      pragha_playlist_go_next_track (playlist);
+      return;
+   } else {
+      gui_backend_error_show_dialog_cb (backend, error, pragha);
+   }
+
 }
 
 static gboolean

--- a/src/pragha-window.c
+++ b/src/pragha-window.c
@@ -137,11 +137,10 @@ gui_backend_error_update_current_playlist_cb (PraghaBackend *backend, const GErr
 
    /* 
     * Don't show error dialog if the playback of the currupted file 
-    * is not started by user explicitly 
+    * is not started by user explicitly otherwise play next track
     */
    if (pragha_playlist_get_implicit_track(playlist)) {
       pragha_playlist_go_next_track (playlist);
-      return;
    } else {
       gui_backend_error_show_dialog_cb (backend, error, pragha);
    }

--- a/src/pragha-window.c
+++ b/src/pragha-window.c
@@ -34,6 +34,7 @@
 #include "pragha-playlists-mgmt.h"
 #include "pragha-session.h"
 #include "pragha-utils.h"
+#include "pragha-playlist.h"
 
 /********************************/
 /* Externally visible functions */
@@ -105,6 +106,16 @@ void
 gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error, gpointer user_data)
 {
 	PraghaApplication *pragha = user_data;
+   PraghaPlaylist *playlist = pragha_application_get_playlist (pragha);
+
+   /* 
+    * Don't show error dialog if the playback of the currupted file 
+    * is not started by user explicitly 
+    */
+   if (pragha_playlist_get_implicit_track(playlist)) {
+      return;
+   }
+
 	GtkWidget *dialog;
 
 	const gchar *file = pragha_musicobject_get_file (pragha_backend_get_musicobject (backend));

--- a/src/pragha-window.h
+++ b/src/pragha-window.h
@@ -28,7 +28,7 @@ gboolean pragha_close_window        (GtkWidget *widget, GdkEvent *event, PraghaA
 void     pragha_destroy_window      (GtkWidget *widget, PraghaApplication *pragha);
 void     pragha_window_toggle_state (PraghaApplication *pragha, gboolean ignoreActivity);
 
-void     gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error, gpointer user_data);
+void     gui_backend_error_show_dialog_cb (PraghaBackend *backend, const GError *error,  PraghaApplication *pragha);
 void     gui_backend_error_update_current_playlist_cb (PraghaBackend *backend, const GError *error, PraghaApplication *pragha);
 
 void     pragha_window_unfullscreen          (GObject *object, PraghaApplication *pragha);

--- a/src/pragha.c
+++ b/src/pragha.c
@@ -1128,8 +1128,8 @@ pragha_application_startup (GApplication *application)
 	g_signal_connect (pragha->backend, "tags-changed",
 	                  G_CALLBACK(pragha_backend_tags_changed), pragha);
 
-	//g_signal_connect (pragha->backend, "error",
-	 //                 G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
+	g_signal_connect (pragha->backend, "error",
+	                  G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
 	g_signal_connect (pragha->backend, "error",
 	                  G_CALLBACK(gui_backend_error_update_current_playlist_cb), pragha);
 	g_signal_connect (pragha->backend, "notify::state",

--- a/src/pragha.c
+++ b/src/pragha.c
@@ -1128,8 +1128,8 @@ pragha_application_startup (GApplication *application)
 	g_signal_connect (pragha->backend, "tags-changed",
 	                  G_CALLBACK(pragha_backend_tags_changed), pragha);
 
-	g_signal_connect (pragha->backend, "error",
-	                 G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
+	//g_signal_connect (pragha->backend, "error",
+	 //                G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
 	g_signal_connect (pragha->backend, "error",
 	                  G_CALLBACK(gui_backend_error_update_current_playlist_cb), pragha);
 	g_signal_connect (pragha->backend, "notify::state",

--- a/src/pragha.c
+++ b/src/pragha.c
@@ -1129,7 +1129,7 @@ pragha_application_startup (GApplication *application)
 	                  G_CALLBACK(pragha_backend_tags_changed), pragha);
 
 	//g_signal_connect (pragha->backend, "error",
-	 //                G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
+	 //                 G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
 	g_signal_connect (pragha->backend, "error",
 	                  G_CALLBACK(gui_backend_error_update_current_playlist_cb), pragha);
 	g_signal_connect (pragha->backend, "notify::state",

--- a/src/pragha.c
+++ b/src/pragha.c
@@ -1128,8 +1128,8 @@ pragha_application_startup (GApplication *application)
 	g_signal_connect (pragha->backend, "tags-changed",
 	                  G_CALLBACK(pragha_backend_tags_changed), pragha);
 
-	g_signal_connect (pragha->backend, "error",
-	                  G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
+	//g_signal_connect (pragha->backend, "error",
+	 //                 G_CALLBACK(gui_backend_error_show_dialog_cb), pragha);
 	g_signal_connect (pragha->backend, "error",
 	                  G_CALLBACK(gui_backend_error_update_current_playlist_cb), pragha);
 	g_signal_connect (pragha->backend, "notify::state",


### PR DESCRIPTION
_>Corrupt files should not block advancing in play list #129_

Fist of all the player should not stop the playback when it suddenly  "finds" a corrupted file in the playlist. This is done by a quick fix.

But it wouldn't be a good solution to just get rid of the error message. So I decided to keep the error message dialog but show it only in certain occasions: when user explicitly wants to play a file that is corrupted.

In order to achieve it I had to add a variable to the _PraghaPlaylist struct. 
`   /* Useful flags */

   gboolean             changing;
   gboolean             dragging;
   gboolean             implicit_track;
   gint                 no_tracks;
   GError              *track_error;
`
The variable implicit_track indicates that a music object is to be played from somewhere in the middle of the playlist, after calling of the functions **go_prev_track** and **go_next_track**.

That variable is checked after updating the playlist and setting the mark in the file line indicating that the file is corrupted (_pragha-window.c_).
`void
gui_backend_error_update_current_playlist_cb (PraghaBackend *backend, const GError *error, PraghaApplication *pragha)
{
   PraghaPlaylist *playlist;
   playlist = pragha_application_get_playlist (pragha);

   pragha_playlist_set_track_error (playlist, pragha_backend_get_error (backend));

   /*  
    * Don't show error dialog if the playback of the currupted file 
    * is not started by user explicitly 
    */
   if (pragha_playlist_get_implicit_track(playlist)) {
      pragha_playlist_go_next_track (playlist);
      return;
   } else {
      gui_backend_error_show_dialog_cb (backend, error, pragha);
   }   

}
`


