### PR TITLE
Split Pragha between the application and a library to link the plugins.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,15 +82,19 @@ if test x"$HAVE_XDT_CSOURCE" != xyes; then
   AC_MSG_FAILURE([xdt-csource not installed])
 fi
 
-GSTREAMER_REQUIRED=0.11.90
 
 dnl Check for required packages
-XDT_CHECK_PACKAGE([GSTREAMER], [gstreamer-1.0], [$GSTREAMER_REQUIRED])
-XDT_CHECK_PACKAGE([GSTREAMER_BASE], [gstreamer-base-1.0], [$GSTREAMER_REQUIRED])
-XDT_CHECK_PACKAGE([GIO], [gio-2.0], [2.42])
-XDT_CHECK_PACKAGE([GTK], [gtk+-3.0], [3.14.0])
-XDT_CHECK_PACKAGE([SQLITE3], [sqlite3], [3.4])
-XDT_CHECK_PACKAGE([TAGLIB_C], [taglib_c], [1.8])
+PKG_CHECK_MODULES(PRAGHA, \
+	gstreamer-1.0 >= 0.11.90 \
+	gstreamer-base-1.0 >= 0.11.90 \
+	gio-2.0 >= 2.42 \
+	gtk+-3.0 >= 3.14 \
+	sqlite3 >= 3.4 \
+	taglib_c >= 1.8)
+
+AC_SUBST(PRAGHA_CFLAGS)
+AC_SUBST(PRAGHA_LIBS)
+
 
 dnl Check peas library to plugins support
 LIBPEAS_FOUND="no"
@@ -103,6 +107,67 @@ if test x"$LIBPEAS_FOUND" = x"yes"; then
 XDT_CHECK_PACKAGE([LIBPEAS_GTK], [libpeas-gtk-1.0], [1.0.0])
 fi
 
+PRAGHA_CFLAGS+=" $LIBPEAS_CFLAGS $LIBPEAS_GTK_CFLAGS"
+PRAGHA_LIBS+=" $LIBPEAS_LIBS $LIBPEAS_GTK_LIBS"
+
+
+dnl Check gstreamer-audio
+GSTREAMER_AUDIO_FOUND="no"
+XDT_CHECK_OPTIONAL_PACKAGE([GSTREAMER_AUDIO],
+                       [gstreamer-audio-1.0], 0.11.90,
+                       [gstreamer-audio],
+                       [gstreamer-audio], [yes])
+
+PRAGHA_CFLAGS+=" $GSTREAMER_AUDIO_CFLAGS"
+PRAGHA_LIBS+=" $GSTREAMER_AUDIO_LIBS"
+
+
+dnl Check libxfce4ui
+LIBXFCE4UI_FOUND="no"
+XDT_CHECK_OPTIONAL_PACKAGE([LIBXFCE4UI],
+                       [libxfce4ui-2], [4.10.0],
+                       [libxfce4ui],
+                       [libxfce4ui library], [yes])
+
+PRAGHA_CFLAGS+=" $LIBXFCE4UI_CFLAGS"
+PRAGHA_LIBS+=" $LIBXFCE4UI_LIBS"
+
+
+dnl Check totem-pl-parser
+PLPARSER_FOUND="no"
+XDT_CHECK_OPTIONAL_PACKAGE([PLPARSER],
+                       [totem-plparser], [2.26],
+                       [totem-plparser],
+                       [totem-plparser library], [yes])
+
+PRAGHA_CFLAGS+=" $PLPARSER_CFLAGS"
+PRAGHA_LIBS+=" $PLPARSER_LIBS"
+
+
+dnl Check for gudev
+GUDEV_FOUND="no"
+if test x"$LIBPEAS_FOUND" = x"yes"; then
+XDT_CHECK_OPTIONAL_PACKAGE([GUDEV],
+                           [gudev-1.0], [145],
+                           [gudev-1.0],
+                           [gudev-1.0 library], [yes])
+else
+AM_CONDITIONAL([HAVE_GUDEV], 0)
+fi
+
+PRAGHA_CFLAGS+=" $GUDEV_CFLAGS"
+PRAGHA_LIBS+=" $GUDEV_LIBS"
+
+
+dnl Check dbus plugins support
+DBUS_PLUGINS_SUPPORT="no"
+if test x"$LIBPEAS_FOUND" = x"yes" && test x"$WIN32" = x"no"; then
+DBUS_PLUGINS_SUPPORT="yes"
+fi
+
+AM_CONDITIONAL([DBUS_PLUGINS_SUPPORT], test "$DBUS_PLUGINS_SUPPORT" = "yes")
+
+
 dnl Check notify support
 LIBNOTIFY_FOUND="no"
 if test x"$LIBPEAS_FOUND" = x"yes"; then
@@ -113,6 +178,7 @@ XDT_CHECK_OPTIONAL_PACKAGE([LIBNOTIFY],
 else
 AM_CONDITIONAL([HAVE_LIBNOTIFY], 0)
 fi
+
 
 dnl Check global keyboard shortcuts support
 LIBKEYBINDER_FOUND="no"
@@ -125,6 +191,7 @@ else
 AM_CONDITIONAL([HAVE_LIBKEYBINDER], 0)
 fi
 
+
 dnl Check libglyr
 LIBGLYR_FOUND="no"
 if test x"$LIBPEAS_FOUND" = x"yes"; then
@@ -136,15 +203,6 @@ else
 AM_CONDITIONAL([HAVE_LIBGLYR], 0)
 fi
 
-GUDEV_FOUND="no"
-if test x"$LIBPEAS_FOUND" = x"yes"; then
-XDT_CHECK_OPTIONAL_PACKAGE([GUDEV],
-                           [gudev-1.0], [145],
-                           [gudev-1.0],
-                           [gudev-1.0 library], [yes])
-else
-AM_CONDITIONAL([HAVE_GUDEV], 0)
-fi
 
 LIBMTP_FOUND="no"
 if test x"$GUDEV_FOUND" = x"yes"; then
@@ -155,6 +213,7 @@ XDT_CHECK_OPTIONAL_PACKAGE([LIBMTP],
 else
 AM_CONDITIONAL([HAVE_LIBMTP], 0)
 fi
+
 
 dnl Check libpsuop
 LIBSOUP_FOUND="no"
@@ -167,6 +226,7 @@ else
 AM_CONDITIONAL([HAVE_LIBSOUP], 0)
 fi
 
+
 dnl Check libpsuop
 JSON_GLIB_FOUND="no"
 if test x"$LIBPEAS_FOUND" = x"yes"; then
@@ -178,6 +238,7 @@ else
 AM_CONDITIONAL([HAVE_JSON_GLIB], 0)
 fi
 
+
 dnl Check rygel
 RYGEL_FOUND="no"
 if test x"$LIBPEAS_FOUND" = x"yes"; then
@@ -188,6 +249,7 @@ XDT_CHECK_OPTIONAL_PACKAGE([RYGEL],
 else
 AM_CONDITIONAL([HAVE_RYGEL], 0)
 fi
+
 
 dnl Check grilo
 GRILO_FOUND="no"
@@ -218,6 +280,7 @@ if test x"$GRILO2_FOUND" = x"yes"; then
 GRILO_FOUND="yes"
 fi
 
+
 dnl Check grilo-net
 GRILO_NET_FOUND="no"
 GRILO_NET3_FOUND="no"
@@ -247,6 +310,7 @@ if test x"$GRILO_NET2_FOUND" = x"yes"; then
 GRILO_NET_FOUND="yes"
 fi
 
+
 dnl Check libclastfm
 LIBCLASTFM_FOUND="no"
 if test x"$LIBPEAS_FOUND" = x"yes"; then
@@ -257,6 +321,7 @@ XDT_CHECK_OPTIONAL_PACKAGE([LIBCLASTFM],
 else
 AM_CONDITIONAL([HAVE_LIBCLASTFM], 0)
 fi
+
 
 dnl Check libcdio, libcdio_paranoia and libcddb
 LIBCDIO_FOUND="no"
@@ -284,42 +349,20 @@ AM_CONDITIONAL([HAVE_LIBCDDB], 0)
 fi
 
 CDROM_SUPPORT="no"
-if test x"$LIBCDIO_FOUND" = x"yes"; then
-if test x"$LIBCDIO_PARANOIA_FOUND" = x"yes"; then
-if test x"$LIBCDDB_FOUND" = x"yes"; then
+if test x"$LIBCDIO_FOUND" = x"yes"  &&
+   test x"$LIBCDIO_PARANOIA_FOUND" = x"yes" &&
+   test x"$LIBCDDB_FOUND" = x"yes"; then
 CDROM_SUPPORT="yes"
 fi
-fi
-fi
+
 
 KOEL_SUPPORT="no"
-if test x"$LIBSOUP_FOUND" = x"yes"; then
-if test x"$JSON_GLIB_FOUND" = x"yes"; then
+if test x"$LIBPEAS_FOUND" = x"yes" &&
+   test x"$LIBSOUP_FOUND" = x"yes" &&
+   test x"$JSON_GLIB_FOUND" = x"yes"; then
 KOEL_SUPPORT="yes"
 fi
-fi
 
-
-dnl Check gstreamer-audio
-GSTREAMER_AUDIO_FOUND="no"
-XDT_CHECK_OPTIONAL_PACKAGE([GSTREAMER_AUDIO],
-                       [gstreamer-audio-1.0], [$GSTREAMER_REQUIRED],
-                       [gstreamer-audio],
-                       [gstreamer-audio], [yes])
-
-dnl Check libxfce4ui
-LIBXFCE4UI_FOUND="no"
-XDT_CHECK_OPTIONAL_PACKAGE([LIBXFCE4UI],
-                       [libxfce4ui-2], [4.10.0],
-                       [libxfce4ui],
-                       [libxfce4ui library], [yes])
-
-dnl Check totem-pl-parser
-PLPARSER_FOUND="no"
-XDT_CHECK_OPTIONAL_PACKAGE([PLPARSER],
-                       [totem-plparser], [2.26],
-                       [totem-plparser],
-                       [totem-plparser library], [yes])
 
 dnl Output files
 AC_CONFIG_FILES([Makefile])
@@ -371,8 +414,8 @@ echo "  Debug enabled.........: $debug"
 echo ""
 echo "  Plugins enabled.......: $LIBPEAS_FOUND"
 echo "   * Show notification when change songs..........(Need libnotify >= 0.7.5).: $LIBNOTIFY_FOUND"
-echo "   * Controls Pragha using Mpris2 interface.................................: $LIBPEAS_FOUND"
-echo "   * Controls Pragha using gnome-media-keys interface.......................: $LIBPEAS_FOUND"
+echo "   * Controls Pragha using Mpris2 interface.................................: $DBUS_PLUGINS_SUPPORT"
+echo "   * Controls Pragha using gnome-media-keys interface.......................: $DBUS_PLUGINS_SUPPORT"
 echo "   * Play Audio cds...............(Need libcdio, libcdio_paranoia, libcddb).: $CDROM_SUPPORT"
 echo "   * Controls Pragha using multimedia keys....(Need keybinder-3.0 >= 0.2.0).: $LIBKEYBINDER_FOUND"
 echo "   * Search lyrics, artists info and albums art.....(Need libglyr >= 1.0.1).: $LIBGLYR_FOUND"

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -6,13 +6,17 @@ AM_CPPFLAGS =								\
 	$(WARN_CFLAGS)							\
 	$(DISABLE_DEPRECATED)
 
-pluginincludedir = $(includedir)/pragha/plugins
+pluginincludedir = $(includedir)/libpragha/plugins
 plugininclude_HEADERS = pragha-plugin-macros.h
 
-SUBDIRS =              \
-	mpris2             \
-	gnome-media-keys \
+SUBDIRS = \
 	visualizer
+
+if DBUS_PLUGINS_SUPPORT
+SUBDIRS += \
+	mpris2 \
+	gnome-media-keys
+endif
 
 if HAVE_LIBGLYR
 SUBDIRS += song-info

--- a/plugins/acoustid/Makefile.am
+++ b/plugins/acoustid/Makefile.am
@@ -12,40 +12,14 @@ libacoustid_la_SOURCES =      \
 
 libacoustid_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libacoustid_la_CFLAGS =						\
-	$(LIBSOUP_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libacoustid_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBSOUP_CFLAGS)
 
-libacoustid_la_LIBADD =						\
-	$(LIBSOUP_LIBS) 						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libacoustid_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libacoustid_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libacoustid_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libacoustid_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libacoustid_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBSOUP_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = acoustid.plugin
 

--- a/plugins/ampache/Makefile.am
+++ b/plugins/ampache/Makefile.am
@@ -13,30 +13,14 @@ libpampache_la_SOURCES =		\
 
 libpampache_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libpampache_la_CFLAGS =						\
-	$(GRILO_NET_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)				\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 					\
-	-I$(top_srcdir)/src/include 			\
-	-Wall
+libpampache_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(GRILO_NET_CFLAGS)
 
-libpampache_la_LIBADD =						\
-	$(GRILO_NET_LIBS) 						\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
+libpampache_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(GRILO_NET_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 if HAVE_GRILO3
 libpampache_la_CFLAGS += $(GRILO_NET3_CFLAGS)
@@ -45,16 +29,6 @@ endif
 if HAVE_GRILO2
 libpampache_la_CFLAGS += $(GRILO_NET2_CFLAGS)
 libpampache_la_LIBADD += $(GRILO_NET2_LIBS)
-endif
-
-if HAVE_GSTREAMER_AUDIO
-libpampache_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libpampache_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libpampache_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libpampache_la_LIBADD += $(LIBXFCE4UI_LIBS)
 endif
 
 plugin_DATA = ampache.plugin

--- a/plugins/cdrom/Makefile.am
+++ b/plugins/cdrom/Makefile.am
@@ -13,48 +13,17 @@ libcdrom_la_SOURCES =      \
 
 libcdrom_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libcdrom_la_CFLAGS =						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	$(LIBCDIO_CFLAGS) 						\
-	$(LIBCDDB_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libcdrom_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBCDIO_CFLAGS) \
+	$(LIBCDDB_CFLAGS)
 
-libcdrom_la_LIBADD =						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)						\
-	$(LIBCDIO_LIBS) 						\
-	$(LIBCDIO_PARANOIA_LIBS) 					\
-	$(LIBCDDB_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libcdrom_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libcdrom_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libcdrom_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libcdrom_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
-
-if HAVE_GUDEV
-libcdrom_la_CFLAGS += $(GUDEV_CFLAGS)
-libcdrom_la_LIBADD += $(GUDEV_LIBS)
-endif
+libcdrom_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBCDIO_LIBS) \
+	$(LIBCDIO_PARANOIA_LIBS) \
+	$(LIBCDDB_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = cdrom.plugin
 

--- a/plugins/dlna-renderer/Makefile.am
+++ b/plugins/dlna-renderer/Makefile.am
@@ -13,28 +13,12 @@ libpdlnarenderer_la_SOURCES =		\
 
 libpdlnarenderer_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libpdlnarenderer_la_CFLAGS =				\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)				\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 					\
-	-I$(top_srcdir)/src/include 			\
-	-Wall
+libpdlnarenderer_la_CFLAGS = \
+	$(PRAGHA_CFLAGS)
 
-libpdlnarenderer_la_LIBADD =				\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
+libpdlnarenderer_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 if HAVE_GRILO3
 libpdlnarenderer_la_CFLAGS += $(GRILO3_CFLAGS)
@@ -43,16 +27,6 @@ endif
 if HAVE_GRILO2
 libpdlnarenderer_la_CFLAGS += $(GRILO2_CFLAGS)
 libpdlnarenderer_la_LIBADD += $(GRILO2_LIBS)
-endif
-
-if HAVE_GSTREAMER_AUDIO
-libpdlnarenderer_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libpdlnarenderer_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libpdlnarenderer_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libpdlnarenderer_la_LIBADD += $(LIBXFCE4UI_LIBS)
 endif
 
 plugin_DATA = dlna-renderer.plugin

--- a/plugins/dlna/Makefile.am
+++ b/plugins/dlna/Makefile.am
@@ -13,40 +13,14 @@ libdlna_la_SOURCES =      \
 
 libdlna_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libdlna_la_CFLAGS =						\
-	$(RYGEL_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libdlna_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(RYGEL_CFLAGS)
 
-libdlna_la_LIBADD =						\
-	$(RYGEL_LIBS) 						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libdlna_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libdlna_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libdlna_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libdlna_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libdlna_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(RYGEL_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = dlna.plugin
 

--- a/plugins/gnome-media-keys/Makefile.am
+++ b/plugins/gnome-media-keys/Makefile.am
@@ -13,28 +13,12 @@ libgnome_media_keys_la_SOURCES =       \
 
 libgnome_media_keys_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libgnome_media_keys_la_CFLAGS =						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libgnome_media_keys_la_CFLAGS = \
+	$(PRAGHA_CFLAGS)
 
-libgnome_media_keys_la_LIBADD =						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
+libgnome_media_keys_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = gnome-media-keys.plugin
 

--- a/plugins/keybinder/Makefile.am
+++ b/plugins/keybinder/Makefile.am
@@ -13,40 +13,14 @@ libkeybinder_la_SOURCES =      \
 
 libkeybinder_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libkeybinder_la_CFLAGS =						\
-	$(LIBKEYBINDER_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libkeybinder_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBKEYBINDER_CFLAGS)
 
-libkeybinder_la_LIBADD =						\
-	$(LIBKEYBINDER_LIBS) 						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libkeybinder_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libkeybinder_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libkeybinder_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libkeybinder_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libkeybinder_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBKEYBINDER_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = keybinder.plugin
 

--- a/plugins/koel/Makefile.am
+++ b/plugins/koel/Makefile.am
@@ -13,42 +13,16 @@ libpkoel_la_SOURCES =		\
 
 libpkoel_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libpkoel_la_CFLAGS =						\
-	$(LIBSOUP_CFLAGS)						\
-	$(JSON_GLIB_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)				\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 					\
-	-I$(top_srcdir)/src/include 			\
-	-Wall
+libpkoel_la_CFLAGS = \
+	$(LIBSOUP_CFLAGS) \
+	$(JSON_GLIB_CFLAGS) \
+	$(PRAGHA_CFLAGS)
 
-libpkoel_la_LIBADD =						\
-	$(LIBSOUP_LIBS)							\
-	$(JSON_GLIB_LIBS)						\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libpkoel_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libpkoel_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libpkoel_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libpkoel_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libpkoel_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBSOUP_LIBS) \
+	$(JSON_GLIB_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = koel.plugin
 

--- a/plugins/lastfm/Makefile.am
+++ b/plugins/lastfm/Makefile.am
@@ -12,43 +12,17 @@ libplastfm_la_SOURCES =      \
 
 libplastfm_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libplastfm_la_CFLAGS =						\
-	$(LIBCLASTFM_CFLAGS)					\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)				\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 					\
-	-I$(top_srcdir)/src/include 			\
-	-Wall
+libplastfm_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBCLASTFM_CFLAGS)
 
-libplastfm_la_LIBADD =						\
-	$(LIBCLASTFM_LIBS)						\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libplastfm_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libplastfm_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libplastfm_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libplastfm_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libplastfm_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBCLASTFM_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 pragha-lastfm-menu-ui.h: pragha-lastfm-menu.ui Makefile
-	$(AM_V_GEN) exo-csource --strip-comments --strip-content --static --name=lastfm_menu_ui $< > $@
+	$(AM_V_GEN) xdt-csource --strip-comments --strip-content --static --name=lastfm_menu_ui $< > $@
 
 plugin_DATA = lastfm.plugin
 

--- a/plugins/mpris2/Makefile.am
+++ b/plugins/mpris2/Makefile.am
@@ -13,38 +13,13 @@ libmpris2_la_SOURCES =      \
 
 libmpris2_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libmpris2_la_CFLAGS =						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libmpris2_la_CFLAGS = \
+	$(PRAGHA_CFLAGS)
 
-libmpris2_la_LIBADD =						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
+libmpris2_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
-if HAVE_GSTREAMER_AUDIO
-libmpris2_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libmpris2_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libmpris2_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libmpris2_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
 
 plugin_DATA = mpris2.plugin
 

--- a/plugins/mtp/Makefile.am
+++ b/plugins/mtp/Makefile.am
@@ -18,42 +18,14 @@ libpmtp_la_SOURCES = \
 
 libpmtp_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libpmtp_la_CFLAGS =							\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	$(GUDEV_CFLAGS) 						\
-	$(LIBMTP_CFLAGS)						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libpmtp_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBMTP_CFLAGS)
 
-libpmtp_la_LIBADD =							\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)						\
-	$(GUDEV_LIBS) 							\
-	$(LIBMTP_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libpmtp_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libpmtp_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libpmtp_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libpmtp_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libpmtp_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBMTP_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = mtp.plugin
 

--- a/plugins/mtp/pragha-mtp-thread.c
+++ b/plugins/mtp/pragha-mtp-thread.c
@@ -227,7 +227,7 @@ get_stats (PraghaMtpThread *thread, PraghaMtpThreadTask *task)
 	gchar *first_storage_description = NULL;
 	guint64 first_storage_capacity, first_storage_free_space;
 	gchar *second_storage_description = NULL;
-	guint64 second_storage_capacity, second_storage_free_space;
+	guint64 second_storage_capacity = 0, second_storage_free_space = 0;
 	guint8 maximum_battery_level = 0, current_battery_level = 0;
 
 	CDEBUG(DBG_PLUGIN, "Mtp thread %s", G_STRFUNC);

--- a/plugins/notify/Makefile.am
+++ b/plugins/notify/Makefile.am
@@ -12,42 +12,14 @@ libnotify_la_SOURCES =						\
 
 libnotify_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libnotify_la_CFLAGS =						\
-	$(LIBGLYR_CFLAGS)							\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBNOTIFY_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libnotify_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBNOTIFY_CFLAGS)
 
-libnotify_la_LIBADD =						\
-	$(LIBGLYR_LIBS) 							\
-	$(GSTREAMER_LIBS)							\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)							\
-	$(LIBNOTIFY_LIBS) 						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libnotify_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libnotify_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libnotify_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libnotify_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libnotify_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBNOTIFY_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = notify.plugin
 

--- a/plugins/removable-media/Makefile.am
+++ b/plugins/removable-media/Makefile.am
@@ -12,40 +12,12 @@ libremovable_la_SOURCES = \
 
 libremovable_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libremovable_la_CFLAGS =						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	$(GUDEV_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libremovable_la_CFLAGS = \
+	$(PRAGHA_CFLAGS)
 
-libremovable_la_LIBADD =							\
-	$(GSTREAMER_LIBS)						\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)						\
-	$(GUDEV_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libremovable_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libremovable_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libremovable_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libremovable_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libremovable_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = removable.plugin
 

--- a/plugins/song-info/Makefile.am
+++ b/plugins/song-info/Makefile.am
@@ -27,43 +27,18 @@ libsong_info_la_SOURCES =						\
 
 libsong_info_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libsong_info_la_CFLAGS =						\
-	$(LIBGLYR_CFLAGS)							\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libsong_info_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBGLYR_CFLAGS)
 
-libsong_info_la_LIBADD =						\
-	$(LIBGLYR_LIBS) 							\
-	$(GSTREAMER_LIBS)							\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)							\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
+libsong_info_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBGLYR_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
-if HAVE_GSTREAMER_AUDIO
-libsong_info_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libsong_info_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libsong_info_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libsong_info_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
 
 pragha-song-info-ui.h: pragha-song-info.ui Makefile
-	$(AM_V_GEN) exo-csource --strip-comments --strip-content --static --name=pragha_song_info_ui $< > $@
+	$(AM_V_GEN) xdt-csource --strip-comments --strip-content --static --name=pragha_song_info_ui $< > $@
 
 plugin_DATA = song-info.plugin
 

--- a/plugins/song-info/pragha-song-info-thread-pane.c
+++ b/plugins/song-info/pragha-song-info-thread-pane.c
@@ -277,7 +277,13 @@ pragha_songinfo_plugin_get_info_to_pane (PraghaSongInfoPlugin *plugin,
 			glyr_opt_lang_aware_only (&glyr_info->query, TRUE);
 			break;
 		case GLYR_GET_SIMILAR_SONGS:
+			pragha_songinfo_pane_set_title (pane, title);
+			pragha_songinfo_pane_set_text (pane, _("Searching..."), "");
+
 			glyr_opt_number (&glyr_info->query, 50);
+			glyr_opt_artist(&glyr_info->query, artist);
+			glyr_opt_title(&glyr_info->query, title);
+			break;
 		case GLYR_GET_LYRICS:
 			pragha_songinfo_pane_set_title (pane, title);
 			pragha_songinfo_pane_set_text (pane, _("Searching..."), "");

--- a/plugins/tunein/Makefile.am
+++ b/plugins/tunein/Makefile.am
@@ -12,40 +12,15 @@ libtunein_la_SOURCES =      \
 
 libtunein_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libtunein_la_CFLAGS =						\
-	$(LIBSOUP_CFLAGS)						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libtunein_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	$(LIBSOUP_CFLAGS)
 
-libtunein_la_LIBADD =						\
-	$(LIBSOUP_LIBS) 						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
 
-if HAVE_GSTREAMER_AUDIO
-libtunein_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libtunein_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libtunein_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libtunein_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libtunein_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(LIBSOUP_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = tunein.plugin
 

--- a/plugins/visualizer/Makefile.am
+++ b/plugins/visualizer/Makefile.am
@@ -17,38 +17,12 @@ libvisualizer_la_SOURCES =      \
 
 libvisualizer_la_LDFLAGS = $(PLUGIN_LIBTOOL_FLAGS)
 
-libvisualizer_la_CFLAGS =						\
-	$(GSTREAMER_CFLAGS)						\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	$(LIBPEAS_CFLAGS) 						\
-	$(LIBPEAS_GTK_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
-	-Wall
+libvisualizer_la_CFLAGS = \
+	$(PRAGHA_CFLAGS)
 
-libvisualizer_la_LIBADD =						\
-	$(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)						\
-	$(LIBPEAS_LIBS)							\
-	$(LIBPEAS_GTK_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-libvisualizer_la_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-libvisualizer_la_LIBADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-libvisualizer_la_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-libvisualizer_la_LIBADD += $(LIBXFCE4UI_LIBS)
-endif
+libvisualizer_la_LIBADD = \
+	$(PRAGHA_LIBS) \
+	$(top_builddir)/src/libpragha.la
 
 plugin_DATA = visualizer.plugin
 

--- a/plugins/visualizer/pragha-visualizer-particle.c
+++ b/plugins/visualizer/pragha-visualizer-particle.c
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/* Copyright (C) 2018 matias <mati86dl@gmail.com>                        */
+/* Copyright (C) 2018-2019 matias <mati86dl@gmail.com>                   */
 /*                                                                       */
 /* This program is free software: you can redistribute it and/or modify	 */
 /* it under the terms of the GNU General Public License as published by	 */
@@ -41,7 +41,7 @@ const gdouble ALPHA_MAX = 0.9;
 const gdouble SPIN_MIN = 0.002;
 const gdouble SPIN_MAX = 0.010;
 const gdouble SIZE_MIN = 0.5;
-const gdouble SIZE_MAX = 1.25;
+const gdouble PSIZE_MAX = 1.25;
 
 #ifdef DRAW_DEBUG
 static gint tick_i = 0;
@@ -101,7 +101,7 @@ pragha_particle_reset (PraghaParticle *particle)
 	particle->speed = g_random_double_range (SPEED_MIN, SPEED_MAX);
 	gdk_rgba_parse (&particle->color, COLORS[g_random_int_range (0, G_N_ELEMENTS(COLORS))]);
 
-	particle->size = g_random_double_range (SIZE_MIN, SIZE_MAX);
+	particle->size = g_random_double_range (SIZE_MIN, PSIZE_MAX);
 	particle->spin = g_random_double_range (SPIN_MIN, SPIN_MAX);
 
 	if (g_random_double_range (0.0, 1.0) < 0.5)

--- a/plugins/visualizer/pragha-visualizer-plugin.c
+++ b/plugins/visualizer/pragha-visualizer-plugin.c
@@ -1,6 +1,6 @@
 /*************************************************************************/
-/* Copyright (C) 2018 matias <mati86dl@gmail.com>                        */
-/*                                                       */
+/* Copyright (C) 2018-2019 matias <mati86dl@gmail.com>                   */
+/*                                                                       */
 /* This program is free software: you can redistribute it and/or modify  */
 /* it under the terms of the GNU General Public License as published by  */
 /* the Free Software Foundation, either version 3 of the License, or     */
@@ -29,7 +29,6 @@
 #include <glib-object.h>
 #include <gmodule.h>
 #include <gtk/gtk.h>
-#include <gdk/gdkx.h>
 
 #include <libpeas/peas.h>
 #include <libpeas-gtk/peas-gtk.h>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,7 +22,7 @@ src/pragha-toolbar.c
 src/pragha-utils.c
 src/pragha-window.c
 src/pragha.c
-
+src/main.c
 #
 # Builder Files
 #
@@ -48,6 +48,7 @@ plugins/cdrom/pragha-cdrom-plugin.c
 plugins/dlna/pragha-dlna-plugin.c
 plugins/dlna-renderer/pragha-dlna-renderer-plugin.c
 plugins/lastfm/pragha-lastfm-plugin.c
+plugins/mtp/pragha-mtp-thread.c
 plugins/mpris2/pragha-mpris2-plugin.c
 plugins/notify/pragha-notify-plugin.c
 plugins/koel/pragha-koel-plugin.c

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,5 +2,9 @@ pragha-window-ui.h
 *.deps*
 *.libs*
 pragha
+pragha.exe
 *.o
+*.la
+*.lo
+*.pc
 *~

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = win32
+
 AM_CPPFLAGS =								\
 	-DG_LOG_DOMAIN=\"pragha\"					\
 	-DPACKAGE_LOCALE_DIR=\"$(localedir)\"				\
@@ -144,6 +146,28 @@ endif
 
 
 #
+# WIN32
+#
+if WIN32
+AM_CFLAGS = \
+	-mms-bitfields
+
+AM_LDFLAGS = \
+	-Wl,-subsystem,windows
+
+libpragha_la_LIBADD += \
+	win32/libwin32.la
+endif
+
+
+libpragha_la_LDFLAGS = \
+	-avoid-version \
+	-export-dynamic \
+	-no-undefined \
+	-export-symbols-regex "^[^_].*"
+
+
+#
 # pkgconfig
 #
 pkgconfigdir = $(libdir)/pkgconfig
@@ -158,30 +182,6 @@ EXTRA_DIST += \
 
 DISTCLEANFILES += \
 	$(pkgconfig_DATA)
-
-
-#
-# WIN32
-#
-if WIN32
-libpragha_la_SOURCES += \
-	win32/win32dep.c
-libpragha_HEADERS += \
-	win32/win32dep.h
-
-AM_CFLAGS = \
-	-mms-bitfields
-
-AM_LDFLAGS = \
-	-Wl,-subsystem,windows
-endif
-
-libpragha_la_LDFLAGS = \
-	-avoid-version \
-	-export-dynamic \
-	-no-undefined \
-	-export-symbols-regex "^[^_].*"
-# endif WIN32
 
 
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,3 @@
-bin_PROGRAMS = pragha
-
 AM_CPPFLAGS =								\
 	-DG_LOG_DOMAIN=\"pragha\"					\
 	-DPACKAGE_LOCALE_DIR=\"$(localedir)\"				\
@@ -10,162 +8,165 @@ AM_CPPFLAGS =								\
 	-DUSRSTYLEDIR=\""$(datadir)/pragha/style"\"	\
 	-I$(top_srcdir)
 
-pragha_SOURCES = \
-	gtkcellrendererbubble.c \
+EXTRA_DIST =
+DISTCLEANFILES =
+
+#
+# Pragha library
+#
+pkglib_LTLIBRARIES = libpragha.la
+
+libpraghadir = $(includedir)/libpragha
+libpragha_HEADERS = \
 	gtkcellrendererbubble.h \
-	info-bar-import-music.c \
-	pragha-album-art.c \
 	pragha-album-art.h \
-	pragha-app-notification.c \
 	pragha-app-notification.h \
-	pragha-app-notification-container.c \
 	pragha-app-notification-container.h \
-	pragha-art-cache.c \
 	pragha-art-cache.h \
-	pragha-backend.c \
 	pragha-backend.h \
-	pragha-background-task-bar.c \
 	pragha-background-task-bar.h \
-	pragha-background-task-widget.c \
 	pragha-background-task-widget.h \
-	pragha-cmdline.c \
-	pragha-database-provider.c \
 	pragha-database-provider.h \
-	pragha-database.c \
 	pragha-database.h \
-	pragha-debug.c \
 	pragha-debug.h \
-	pragha-dnd.c \
 	pragha-dnd.h \
-	pragha-equalizer-dialog.c \
 	pragha-equalizer-dialog.h \
-	pragha-favorites.c \
 	pragha-favorites.h \
-	pragha-file-utils.c \
 	pragha-file-utils.h \
-	pragha-filter-dialog.c \
 	pragha-filter-dialog.h \
-	pragha-hig.c \
-	pragha-hig.h \
-	pragha-library-pane.c \
 	pragha-library-pane.h \
-	pragha-menubar.c \
+	pragha-hig.h \
 	pragha-menubar.h \
-	pragha-music-enum.c \
 	pragha-music-enum.h \
-	pragha-musicobject.c \
 	pragha-musicobject.h \
-	pragha-musicobject-mgmt.c \
 	pragha-musicobject-mgmt.h \
-	pragha-playback.c \
 	pragha-playback.h \
-	pragha-playlist.c \
 	pragha-playlist.h \
-	pragha-playlists-mgmt.c \
 	pragha-playlists-mgmt.h \
-	pragha-preferences.c \
 	pragha-preferences.h \
-	pragha-preferences-dialog.c \
 	pragha-preferences-dialog.h \
-	pragha-prepared-statement.c \
 	pragha-prepared-statement.h \
 	pragha-prepared-statement-private.h \
-	pragha-provider.c \
 	pragha-provider.h \
-	pragha-scanner.c \
 	pragha-scanner.h \
-	pragha-search-entry.c \
 	pragha-search-entry.h \
-	pragha-session.c \
 	pragha-session.h \
-	pragha-sidebar.c \
 	pragha-sidebar.h \
-	pragha-simple-async.c \
 	pragha-simple-async.h \
-	pragha-simple-widgets.c \
 	pragha-simple-widgets.h \
-	pragha-song-cache.c \
 	pragha-song-cache.h \
-	pragha-statusbar.c \
 	pragha-statusbar.h \
-	pragha-statusicon.c \
 	pragha-statusicon.h \
-	pragha-tagger.c \
 	pragha-tagger.h \
-	pragha-tags-dialog.c \
 	pragha-tags-dialog.h \
-	pragha-tags-mgmt.c \
 	pragha-tags-mgmt.h \
-	pragha-temp-provider.c \
 	pragha-temp-provider.h \
-	pragha-toolbar.c \
 	pragha-toolbar.h \
-	pragha-utils.c \
 	pragha-utils.h \
-	pragha-window.c \
 	pragha-window.h \
-	pragha.c \
 	pragha.h \
-	pragha-window-ui.h \
-	xml_helper.c \
 	xml_helper.h
 
-pragha_CFLAGS =	$(GSTREAMER_CFLAGS)					\
-	$(GSTREAMER_BASE_CFLAGS)					\
-	$(GLIB_CFLAGS) 							\
-	$(GIO_CFLAGS) 							\
-	$(GTK_CFLAGS) 							\
-	$(SQLITE3_CFLAGS) 						\
-	$(TAGLIB_C_CFLAGS) 						\
-	-I$(top_srcdir)/src/include 					\
+libpragha_la_SOURCES = \
+	$(libpragha_HEADERS) \
+	$(BUILT_SOURCES) \
+	gtkcellrendererbubble.c \
+	info-bar-import-music.c \
+	pragha-album-art.c \
+	pragha-app-notification.c \
+	pragha-app-notification-container.c \
+	pragha-art-cache.c \
+	pragha-backend.c \
+	pragha-background-task-bar.c \
+	pragha-background-task-widget.c \
+	pragha-cmdline.c \
+	pragha-database-provider.c \
+	pragha-database.c \
+	pragha-debug.c \
+	pragha-dnd.c \
+	pragha-equalizer-dialog.c \
+	pragha-favorites.c \
+	pragha-file-utils.c \
+	pragha-filter-dialog.c \
+	pragha-hig.c \
+	pragha-library-pane.c \
+	pragha-menubar.c \
+	pragha-music-enum.c \
+	pragha-musicobject.c \
+	pragha-musicobject-mgmt.c \
+	pragha-playback.c \
+	pragha-playlist.c \
+	pragha-playlists-mgmt.c \
+	pragha-preferences.c \
+	pragha-preferences-dialog.c \
+	pragha-prepared-statement.c \
+	pragha-provider.c \
+	pragha-scanner.c \
+	pragha-search-entry.c \
+	pragha-session.c \
+	pragha-sidebar.c \
+	pragha-simple-async.c \
+	pragha-simple-widgets.c \
+	pragha-song-cache.c \
+	pragha-statusbar.c \
+	pragha-statusicon.c \
+	pragha-tagger.c \
+	pragha-tags-dialog.c \
+	pragha-tags-mgmt.c \
+	pragha-temp-provider.c \
+	pragha-toolbar.c \
+	pragha-utils.c \
+	pragha-window.c \
+	pragha.c \
+	xml_helper.c
+
+libpragha_la_CFLAGS = \
+	$(PRAGHA_CFLAGS) \
+	-I$(top_srcdir)/src/include \
 	-Wall -lm
 
-pragha_LDADD = $(GSTREAMER_LIBS)					\
-	$(GLIB_LIBS) 							\
-	$(GIO_LIBS) 							\
-	$(GTK_LIBS) 							\
-	$(SQLITE3_LIBS)							\
-	$(TAGLIB_C_LIBS)
-
-if HAVE_GSTREAMER_AUDIO
-pragha_CFLAGS += $(GSTREAMER_AUDIO_CFLAGS)
-pragha_LDADD += $(GSTREAMER_AUDIO_LIBS)
-endif
-
-if HAVE_LIBXFCE4UI
-pragha_CFLAGS += $(LIBXFCE4UI_CFLAGS)
-pragha_LDADD += $(LIBXFCE4UI_LIBS)
-endif
-
-if HAVE_PLPARSER
-pragha_CFLAGS += $(PLPARSER_CFLAGS)
-pragha_LDADD += $(PLPARSER_LIBS)
-endif
+libpragha_la_LIBADD = \
+	$(PRAGHA_LIBS)
 
 if HAVE_LIBPEAS
-pragha_SOURCES += \
-	pragha-plugins-engine.c \
+libpragha_la_SOURCES += \
+	pragha-plugins-engine.c
+libpragha_HEADERS += \
 	pragha-plugins-engine.h
-
-pragha_CFLAGS += $(LIBPEAS_CFLAGS)
-pragha_LDADD += $(LIBPEAS_LIBS)
-
-pragha_CFLAGS += $(LIBPEAS_GTK_CFLAGS)
-pragha_LDADD += $(LIBPEAS_GTK_LIBS)
 endif
 
 if HAVE_GUDEV
-pragha_SOURCES += \
-	pragha-device-client.c \
+libpragha_la_SOURCES += \
+	pragha-device-client.c
+libpragha_HEADERS += \
 	pragha-device-client.h
-
-pragha_CFLAGS += $(GUDEV_CFLAGS)
-pragha_LDADD += $(GUDEV_LIBS)
 endif
 
+
+#
+# pkgconfig
+#
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_in_files = libpragha.pc.in
+pkgconfig_DATA = $(pkgconfig_in_files:.pc.in=.pc)
+
+%.pc: %.pc.in
+	sed "s,\@VERSION\@,$(VERSION),g; s,\@prefix\@,$(prefix),g; s,\@libdir\@,$(libdir),g; s,\@includedir\@,$(includedir),g" < $< > $@
+
+EXTRA_DIST += \
+	$(pkgconfig_in_files)
+
+DISTCLEANFILES += \
+	$(pkgconfig_DATA)
+
+
+#
+# WIN32
+#
 if WIN32
-pragha_SOURCES += \
-	win32/win32dep.c \
+libpragha_la_SOURCES += \
+	win32/win32dep.c
+libpragha_HEADERS += \
 	win32/win32dep.h
 
 AM_CFLAGS = \
@@ -173,21 +174,48 @@ AM_CFLAGS = \
 
 AM_LDFLAGS = \
 	-Wl,-subsystem,windows
-
-pragha-res.o: win32/pragha.rc
-	$(WINDRES) -i win32/pragha.rc --input-format=rc -o pragha-res.o -O coff
-
-pragha_LDADD += pragha-res.o
 endif
 
+libpragha_la_LDFLAGS = \
+	-avoid-version \
+	-export-dynamic \
+	-no-undefined \
+	-export-symbols-regex "^[^_].*"
+# endif WIN32
+
+
+#
+# Build sources
+#
 pragha-window-ui.h: pragha-window.ui Makefile
 	$(AM_V_GEN) xdt-csource --strip-comments --strip-content --static --name=pragha_window_ui $< > $@
 
-EXTRA_DIST = \
-	pragha-window.ui
-
-DISTCLEANFILES = \
-	pragha-window-ui.h
-
 BUILT_SOURCES = \
 	pragha-window-ui.h
+
+DISTCLEANFILES += \
+	pragha-window-ui.h
+
+
+#
+# Pragha binary
+#
+bin_PROGRAMS = pragha
+
+pragha_SOURCES = \
+	main.c
+
+pragha_CFLAGS = \
+	$(libpragha_la_CFLAGS)
+
+pragha_LDADD = \
+	libpragha.la
+
+if WIN32
+pragha-res.o: win32/pragha.rc
+	$(WINDRES) -i win32/pragha.rc --input-format=rc -o pragha-res.o -O coff
+pragha_LDADD += pragha-res.o
+endif
+
+EXTRA_DIST += \
+	pragha-window.ui

--- a/src/libpragha.pc.in
+++ b/src/libpragha.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+libdir=@libdir@/pragha
+includedir=@includedir@/libpragha
+
+Name: libpragha
+Description: Library to write Pragha plugins
+Requires: gstreamer-1.0 gstreamer-base-1.0 gio-2.0 gtk+-3.0 gtk+-3.0 taglib_c libpeas-1.0 libpeas-gtk-1.0
+Version: @VERSION@
+Libs: -L${libdir} -lpragha
+Cflags: -I${includedir}
+

--- a/src/libpragha.pc.in
+++ b/src/libpragha.pc.in
@@ -8,4 +8,3 @@ Requires: gstreamer-1.0 gstreamer-base-1.0 gio-2.0 gtk+-3.0 gtk+-3.0 taglib_c li
 Version: @VERSION@
 Libs: -L${libdir} -lpragha
 Cflags: -I${includedir}
-

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/* Copyright (C) 2007-2009 sujith <m.sujith@gmail.com>                   */
+/* Copyright (C) 2009-2019 matias <mati86dl@gmail.com>                   */
+/*                                                                       */
+/* This program is free software: you can redistribute it and/or modify  */
+/* it under the terms of the GNU General Public License as published by  */
+/* the Free Software Foundation, either version 3 of the License, or     */
+/* (at your option) any later version.                                   */
+/*                                                                       */
+/* This program is distributed in the hope that it will be useful,       */
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of        */
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         */
+/* GNU General Public License for more details.                          */
+/*                                                                       */
+/* You should have received a copy of the GNU General Public License     */
+/* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+/*************************************************************************/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "pragha.h"
+
+#if defined(GETTEXT_PACKAGE)
+#include <glib/gi18n-lib.h>
+#else
+#include <glib/gi18n.h>
+#endif
+
+#include <glib.h>
+#include <locale.h> /* require LC_ALL */
+#include <libintl.h>
+#include <tag_c.h>
+
+#ifdef DEBUG
+GThread *pragha_main_thread = NULL;
+#endif
+
+gint main(gint argc, gchar *argv[])
+{
+    PraghaApplication *pragha;
+    int status;
+#ifdef DEBUG
+    g_print ("debug enabled\n");
+    pragha_main_thread = g_thread_self ();
+#endif
+    debug_level = 0;
+
+    /* setup translation domain */
+    setlocale (LC_ALL, "");
+    bindtextdomain (GETTEXT_PACKAGE, PACKAGE_LOCALE_DIR);
+    bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+    textdomain (GETTEXT_PACKAGE);
+
+    /* Force unicode to taglib. */
+    taglib_set_strings_unicode(TRUE);
+    taglib_set_string_management_enabled(FALSE);
+
+    /* Setup application name and pulseaudio role */
+    g_set_application_name(_("Pragha Music Player"));
+    g_setenv("PULSE_PROP_media.role", "audio", TRUE);
+
+    pragha = pragha_application_new ();
+    status = g_application_run (G_APPLICATION (pragha), argc, argv);
+    g_object_run_dispose (G_OBJECT (pragha));
+    g_object_unref (pragha);
+
+    return status;
+}

--- a/src/pragha-debug.c
+++ b/src/pragha-debug.c
@@ -22,6 +22,8 @@
 
 /* Function to save debug on file. */
 
+gint debug_level;
+
 void
 pragha_log_to_file (const gchar* log_domain,
                     GLogLevelFlags log_level,

--- a/src/pragha-device-client.c
+++ b/src/pragha-device-client.c
@@ -80,7 +80,6 @@ device_type_name (PraghaDeviceType type)
 			return ("UNKNOWN");
 			break;
 	}
-	return ("UNKNOWN");
 }
 
 

--- a/src/pragha-playlist.c
+++ b/src/pragha-playlist.c
@@ -3366,7 +3366,7 @@ init_current_playlist_columns(PraghaPlaylist* cplaylist)
 	const gchar *col_name;
 	GtkTreeViewColumn *col, *last;
 	GList *list = NULL, *i;
-	GSList *slist = NULL, *j, *widths;
+	GSList *slist = NULL, *j, *widths = NULL;
 	gint *col_widths, icon_size, k = 0;
 	gsize cnt = 0, isize;
 

--- a/src/pragha-plugins-engine.c
+++ b/src/pragha-plugins-engine.c
@@ -181,7 +181,7 @@ pragha_plugins_engine_new (GObject *object)
 	engine->object = g_object_ref(object);
 
 	peas_engine_add_search_path (engine->peas_engine, LIBPLUGINDIR, USRPLUGINDIR);
-
+	//peas_engine_add_search_path (engine->peas_engine, "/home/matias/Desarrollo/pragha/plugins/", "/home/matias/Desarrollo/pragha/plugins/");
 	engine->peas_exten_set = peas_extension_set_new (engine->peas_engine,
 	                                                 PEAS_TYPE_ACTIVATABLE,
 	                                                 "object", object,

--- a/src/pragha-toolbar.c
+++ b/src/pragha-toolbar.c
@@ -442,18 +442,15 @@ pragha_toolbar_add_extention_widget(PraghaToolbar *toolbar, GtkWidget *widget)
 void
 pragha_toolbar_add_extra_button (PraghaToolbar *toolbar, GtkWidget *widget)
 {
-	GList *list;
-	GtkWidget *children;
-
-	list = gtk_container_get_children (GTK_CONTAINER(toolbar->extra_button_box));
-	if(list) {
-		children = list->data;
-		gtk_container_remove(GTK_CONTAINER(toolbar->extra_button_box), children);
-		gtk_widget_destroy(GTK_WIDGET(children));
-		g_list_free(list);
-	}
 	gtk_container_add(GTK_CONTAINER(toolbar->extra_button_box), widget);
 }
+
+void
+pragha_toolbar_remove_extra_button (PraghaToolbar *toolbar, GtkWidget *widget)
+{
+	gtk_container_remove(GTK_CONTAINER(toolbar->extra_button_box), widget);
+}
+
 
 const gchar*
 pragha_toolbar_get_progress_text(PraghaToolbar *toolbar)

--- a/src/pragha-toolbar.h
+++ b/src/pragha-toolbar.h
@@ -62,7 +62,9 @@ gboolean pragha_toolbar_window_state_event   (GtkWidget *widget, GdkEventWindowS
 
 void     pragha_toolbar_set_style            (PraghaToolbar *toolbar, gboolean gnome_style);
 void     pragha_toolbar_add_extention_widget (PraghaToolbar *toolbar, GtkWidget *widget);
+
 void     pragha_toolbar_add_extra_button     (PraghaToolbar *toolbar, GtkWidget *widget);
+void     pragha_toolbar_remove_extra_button  (PraghaToolbar *toolbar, GtkWidget *widget);
 
 const gchar    *pragha_toolbar_get_progress_text (PraghaToolbar *toolbar);
 const gchar    *pragha_toolbar_get_length_text   (PraghaToolbar *toolbar);

--- a/src/pragha.c
+++ b/src/pragha.c
@@ -48,11 +48,6 @@
 #include "win32/win32dep.h"
 #endif
 
-gint debug_level;
-#ifdef DEBUG
-GThread *pragha_main_thread = NULL;
-#endif
-
 struct _PraghaApplication {
 	GtkApplication base_instance;
 
@@ -1390,36 +1385,4 @@ pragha_application_new ()
 	                     "application-id", "io.github.pragha_music_player",
 	                     "flags", G_APPLICATION_HANDLES_COMMAND_LINE | G_APPLICATION_HANDLES_OPEN,
 	                     NULL);
-}
-
-gint main(gint argc, gchar *argv[])
-{
-	PraghaApplication *pragha;
-	int status;
-#ifdef DEBUG
-	g_print ("debug enabled\n");
-	pragha_main_thread = g_thread_self ();
-#endif
-	debug_level = 0;
-
-	/* setup translation domain */
-	setlocale (LC_ALL, "");
-	bindtextdomain (GETTEXT_PACKAGE, PACKAGE_LOCALE_DIR);
-	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-	textdomain (GETTEXT_PACKAGE);
-
-	/* Force unicode to taglib. */
-	taglib_set_strings_unicode(TRUE);
-	taglib_set_string_management_enabled(FALSE);
-
-	/* Setup application name and pulseaudio role */
-	g_set_application_name(_("Pragha Music Player"));
-	g_setenv("PULSE_PROP_media.role", "audio", TRUE);
-
-	pragha = pragha_application_new ();
-	status = g_application_run (G_APPLICATION (pragha), argc, argv);
-	g_object_run_dispose (G_OBJECT (pragha));
-	g_object_unref (pragha);
-
-	return status;
 }

--- a/src/pragha.h
+++ b/src/pragha.h
@@ -1,6 +1,6 @@
 /*************************************************************************/
 /* Copyright (C) 2007-2009 sujith <m.sujith@gmail.com>                   */
-/* Copyright (C) 2009-2015 matias <mati86dl@gmail.com>                   */
+/* Copyright (C) 2009-2019 matias <mati86dl@gmail.com>                   */
 /*                                                                       */
 /* This program is free software: you can redistribute it and/or modify  */
 /* it under the terms of the GNU General Public License as published by  */
@@ -123,7 +123,8 @@ typedef struct {
 	GtkApplicationClass parent_class;
 } PraghaApplicationClass;
 
-void pragha_application_quit (PraghaApplication *pragha);
+void                pragha_application_quit (PraghaApplication *pragha);
+PraghaApplication * pragha_application_new  ();
 
 G_END_DECLS
 

--- a/src/win32/Makefile.am
+++ b/src/win32/Makefile.am
@@ -1,4 +1,12 @@
-# Stuff to build the Windows build:
+noinst_LTLIBRARIES=libwin32.la
+
+libwin32_la_SOURCES = \
+	win32dep.c \
+	win32dep.h
+
+libwin32_la_CFLAGS = $(PRAGHA_CFLAGS)
+libwin32_la_LIBADD = $(PRAGHA_LIBS)
+
 EXTRA_DIST = \
 	pragha.ico \
 	pragha.rc


### PR DESCRIPTION
This results in a true plugin system, where other developers can implement 3rd party plugins for extend Pragha.

I wrote a small sample to test how it works:
 * https://github.com/pragha-music-player/pragha-sample-plugin

...that implements the option to start a CD burner application with the current playlist.

Dont remove old widgets when remove extra button on toolbar.. and append an api to it.

Sample plugin:
![imagen](https://user-images.githubusercontent.com/733715/62648504-51e0de80-b929-11e9-9778-bbb3e1b273df.png)

![imagen](https://user-images.githubusercontent.com/733715/62648542-6624db80-b929-11e9-8892-123295b7430c.png)
