### PR TITLE
Fix transifex link in menu bar

### DIFF
--- a/src/pragha-menubar.c
+++ b/src/pragha-menubar.c
@@ -673,7 +673,7 @@ static void wiki_action(GtkAction *action, PraghaApplication *pragha)
 
 static void translate_action(GtkAction *action, PraghaApplication *pragha)
 {
-	const gchar *uri = "http://www.transifex.net/projects/p/Pragha/";
+	const gchar *uri = "http://www.transifex.com/projects/p/Pragha/";
 	open_url(uri, pragha_application_get_window(pragha));
 }
 


### PR DESCRIPTION
Clicking "Help > Tranlate Pragha" currently opens a 404 page.

This is because transifex has moved from `.net` from `.com` domain
a while ago. This commit fixes the link accordingly.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>